### PR TITLE
Remove dockly.rb file

### DIFF
--- a/lib/dockly.rb
+++ b/lib/dockly.rb
@@ -1,4 +1,0 @@
-module Dockly
-end
-
-require 'dockly/util'


### PR DESCRIPTION
@bfulton @adamjt 

This was the problem we were having when require'ing from the system gems.
